### PR TITLE
Use peerstore instead of slice for keeping box peers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.15.1
 	github.com/libp2p/go-libp2p-mplex v0.7.0
 	github.com/libp2p/go-libp2p-noise v0.4.0
+	github.com/multiformats/go-multiaddr v0.5.0
 	google.golang.org/protobuf v1.28.0
 )
 
@@ -82,7 +83,6 @@ require (
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.0.4 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
-	github.com/multiformats/go-multiaddr v0.5.0 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.0.3 // indirect
@@ -108,7 +108,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
-	golang.org/x/mobile v0.0.0-20220518205345-8578da9835fd // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220418201149-a630d4f3e7a2 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/go.sum
+++ b/go.sum
@@ -816,7 +816,6 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
@@ -884,7 +883,6 @@ golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
-golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
@@ -907,8 +905,6 @@ golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
-golang.org/x/mobile v0.0.0-20220518205345-8578da9835fd h1:x1GptNaTtxPAlTVIAJk61fuXg0y17h09DTxyb+VNC/k=
-golang.org/x/mobile v0.0.0-20220518205345-8578da9835fd/go.mod h1:pe2sM7Uk+2Su1y7u/6Z8KJ24D7lepUjFZbhFOrmDfuQ=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
@@ -970,7 +966,6 @@ golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT
 golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220418201149-a630d4f3e7a2 h1:6mzvA99KwZxbOrxww4EvWVQUnN1+xEu9tafK5ZxkYeA=
@@ -1070,7 +1065,6 @@ golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
@@ -1146,7 +1140,6 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.8-0.20211022200916-316ba0b74098/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/mobile/fula.go
+++ b/mobile/fula.go
@@ -17,6 +17,7 @@ import (
 	mplex "github.com/libp2p/go-libp2p-mplex"
 	noise "github.com/libp2p/go-libp2p-noise"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	manet "github.com/multiformats/go-multiaddr/net"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -49,6 +50,20 @@ func (f *Fula) AddBox(boxAddr string) error {
 	if err != nil {
 		return err
 	}
+	var check bool
+	check = len(peerAddr.Addrs) < 0
+	if check {
+		return errors.New("Bad Input")
+	}
+	check = manet.IsIPLoopback(peerAddr.Addrs[0])
+	if check {
+		return errors.New("Cant Use loop back")
+	}
+	check = manet.IsIPUnspecified(peerAddr.Addrs[0])
+	if check {
+		return errors.New("Not Specified")
+	}
+
 	ps := f.node.Peerstore()
 	ps.AddAddrs(peerAddr.ID, peerAddr.Addrs, peerstore.PermanentAddrTTL)
 	ps.AddProtocols(peerAddr.ID, filePL.Protocol, graphPL.Protocol)

--- a/mobile/fula.go
+++ b/mobile/fula.go
@@ -3,6 +3,7 @@ package mobile
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"os"
 
@@ -29,9 +30,8 @@ type IFula interface {
 }
 
 type Fula struct {
-	node  host.Host
-	peers []peer.ID
-	ctx context.Context
+	node host.Host
+	ctx  context.Context
 }
 
 func NewFula() (*Fula, error) {
@@ -44,52 +44,87 @@ func NewFula() (*Fula, error) {
 	return f, nil
 }
 
-func (f *Fula) AddBox(boxAddr string)  error {
+func (f *Fula) AddBox(boxAddr string) error {
 	peerAddr, err := peer.AddrInfoFromString(boxAddr)
-	node := f.node
 	if err != nil {
 		return err
 	}
-	f.peers = append(f.peers, peerAddr.ID)
-	node.Peerstore().AddAddrs(peerAddr.ID, peerAddr.Addrs, peerstore.PermanentAddrTTL)
+	ps := f.node.Peerstore()
+	ps.AddAddrs(peerAddr.ID, peerAddr.Addrs, peerstore.PermanentAddrTTL)
+	ps.AddProtocols(peerAddr.ID, filePL.Protocol, graphPL.Protocol)
 	return nil
 }
 
-func (f *Fula) Send(filePath string) (string,error){
+func (f *Fula) getBox(protocol string) (peer.ID, error) {
+	ps := f.node.Peerstore()
+	allPeers := ps.PeersWithAddrs()
+	log.Println("All peer", allPeers.String())
+	boxPeers := peer.IDSlice{}
+	for _, id := range allPeers {
+		supported, err := ps.SupportsProtocols(id, protocol)
+		if err == nil && len(supported) > 0 {
+			boxPeers = append(boxPeers, id)
+		}
+
+	}
+	log.Println("All peer", boxPeers.String())
+	for _, id := range boxPeers {
+		_, err := f.node.Network().DialPeer(f.ctx, id)
+		if err == nil {
+			return id, nil
+		}
+
+	}
+	return "", errors.New("No Box Available")
+}
+
+func (f *Fula) Send(filePath string) (string, error) {
+	peer, err := f.getBox(filePL.Protocol)
+	if err != nil {
+		return "", err
+	}
 	file, err := os.Open(filePath)
 	if err != nil {
 		return "", err
 	}
 	defer file.Close()
-	stream, err := f.node.NewStream(f.ctx, f.peers[0], filePL.Protocol)
+	stream, err := f.node.NewStream(f.ctx, peer, filePL.Protocol)
 	defer stream.Close()
 	if err != nil {
 		return "", err
 	}
 
-	res,err := filePL.SendFile(file, stream)
+	res, err := filePL.SendFile(file, stream)
 
 	return *res, nil
 }
 
 func (f *Fula) ReceiveFileInfo(fileId string) ([]byte, error) {
-	stream, err := f.node.NewStream(f.ctx, f.peers[0], filePL.Protocol)
+	peer, err := f.getBox(filePL.Protocol)
+	if err != nil {
+		return nil, err
+	}
+	stream, err := f.node.NewStream(f.ctx, peer, filePL.Protocol)
 	defer stream.Close()
 	if err != nil {
 		return nil, err
 	}
-	meta,err := filePL.ReceiveMeta(stream, fileId)
-	
+	meta, err := filePL.ReceiveMeta(stream, fileId)
+
 	return meta, nil
 }
 
-func (f *Fula) ReceiveFile(fileId string, filePath string) (error){
-	stream, err := f.node.NewStream(f.ctx, f.peers[0], filePL.Protocol)
+func (f *Fula) ReceiveFile(fileId string, filePath string) error {
+	peer, err := f.getBox(filePL.Protocol)
+	if err != nil {
+		return err
+	}
+	stream, err := f.node.NewStream(f.ctx, peer, filePL.Protocol)
 	if err != nil {
 		return err
 	}
 	defer stream.Close()
-	fBytes,err := filePL.ReceiveFile(stream, fileId)
+	fBytes, err := filePL.ReceiveFile(stream, fileId)
 	if err != nil {
 		return err
 	}
@@ -100,8 +135,12 @@ func (f *Fula) ReceiveFile(fileId string, filePath string) (error){
 	return nil
 }
 
-func (f *Fula) GraphQL(query string, values string) ([]byte, error){
-	stream, err := f.node.NewStream(f.ctx, f.peers[0], graphPL.Protocol)
+func (f *Fula) GraphQL(query string, values string) ([]byte, error) {
+	peer, err := f.getBox(filePL.Protocol)
+	if err != nil {
+		return nil, err
+	}
+	stream, err := f.node.NewStream(f.ctx, peer, graphPL.Protocol)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Use peerstore instead of slice for keeping box peers
- Don't let user input loopback ip addresses