### PR TITLE
Implement a basic event schema using IPLD

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -1,0 +1,13 @@
+package event
+
+import (
+	"github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type Event struct {
+	Version   string
+	Previous  ipld.Link
+	Peer      peer.ID
+	Signature []byte
+}

--- a/event/example_test.go
+++ b/event/example_test.go
@@ -1,0 +1,78 @@
+package event_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/functionland/go-fula/event"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	_ "github.com/ipld/go-ipld-prime/codec/dagcbor"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+	"github.com/ipld/go-ipld-prime/storage/memstore"
+	"github.com/multiformats/go-multicodec"
+)
+
+var lp = cidlink.LinkPrototype{
+	Prefix: cid.Prefix{
+		Version:  1,
+		Codec:    uint64(multicodec.DagCbor),
+		MhType:   uint64(multicodec.Sha2_256),
+		MhLength: -1,
+	},
+}
+
+// ExampleEventChain creates three events, chains them together and stores them via ipld.DefaultLinkSystem.
+func ExampleEventChain() {
+	first := &event.Event{
+		Version:   event.Version0,
+		Peer:      "1",
+		Signature: []byte("sig1"),
+	}
+	second := &event.Event{
+		Version:   event.Version0,
+		Peer:      "2",
+		Signature: []byte("sig2"),
+	}
+	third := &event.Event{
+		Version:   event.Version0,
+		Peer:      "3",
+		Signature: []byte("sig3"),
+	}
+
+	ls := cidlink.DefaultLinkSystem()
+	store := &memstore.Store{}
+	ls.SetReadStorage(store)
+	ls.SetWriteStorage(store)
+
+	ctx := context.Background()
+
+	n := bindnode.Wrap(first, event.Prototypes.Event.Type())
+	if l, err := ls.Store(ipld.LinkContext{Ctx: ctx}, lp, n); err != nil {
+		panic(err)
+	} else {
+		second.Previous = l
+		fmt.Printf("Link to 1st event: %s\n", l.String())
+	}
+
+	n = bindnode.Wrap(second, event.Prototypes.Event.Type())
+	if l, err := ls.Store(ipld.LinkContext{Ctx: ctx}, lp, n); err != nil {
+		panic(err)
+	} else {
+		third.Previous = l
+		fmt.Printf("Link to 2nd event: %s\n", l.String())
+	}
+
+	n = bindnode.Wrap(third, event.Prototypes.Event.Type())
+	if l, err := ls.Store(ipld.LinkContext{Ctx: ctx}, lp, n); err != nil {
+		panic(err)
+	} else {
+		fmt.Printf("Link to 3rd event: %s\n", l.String())
+	}
+
+	// output:
+	// Link to 1st event: bafyreid3ehnrqi5bgyy73s42kevtcoa4tjol2rzwytnfk6222aict4hkam
+	// Link to 2nd event: bafyreiaip6euzqqan5ujs322xe7ih653onk4lib2lsykeyvkd4uhcl6aea
+	// Link to 3rd event: bafyreie7ycr7yqqprsn5k4zcuyvo6ap47dl2hwpea5dfo3owpdkj6ovtvm
+}

--- a/event/schema.go
+++ b/event/schema.go
@@ -1,0 +1,29 @@
+package event
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+const Version0 = "0"
+
+var (
+	Prototypes struct {
+		Event schema.TypedPrototype
+	}
+
+	//go:embed schema.ipldsch
+	schemaBytes []byte
+)
+
+func init() {
+	typeSystem, err := ipld.LoadSchemaBytes(schemaBytes)
+	if err != nil {
+		panic(fmt.Errorf("cannot load schema: %w", err))
+	}
+	Prototypes.Event = bindnode.Prototype((*Event)(nil), typeSystem.TypeByName("Event"))
+}

--- a/event/schema.ipldsch
+++ b/event/schema.ipldsch
@@ -1,0 +1,6 @@
+type Event struct {
+    Version   String
+    Previous  optional Link
+    Peer      String
+    Signature Bytes
+}

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/ipfs/go-unixfs v0.4.0
 	github.com/ipfs/interface-go-ipfs-core v0.7.0
 	github.com/ipfs/kubo v0.14.0
+	github.com/ipld/go-ipld-prime v0.17.0
 	github.com/libp2p/go-libp2p v0.20.3
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/libp2p/go-libp2p-kad-dht v0.16.0
@@ -39,11 +40,11 @@ require (
 	github.com/mergermarket/go-pkcs7 v0.0.0-20170926155232-153b18ea13c9
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/multiformats/go-multiaddr-dns v0.3.1
+	github.com/multiformats/go-multicodec v0.5.0
 	go.opentelemetry.io/otel v1.7.0
+	go.opentelemetry.io/otel/trace v1.7.0
 	google.golang.org/protobuf v1.28.0
 )
-
-replace github.com/ipfs/kubo => ../kubo
 
 require (
 	bazil.org/fuse v0.0.0-20200117225306-7b5117fecadc // indirect
@@ -119,7 +120,6 @@ require (
 	github.com/ipfs/go-verifcid v0.0.1 // indirect
 	github.com/ipld/edelweiss v0.1.4 // indirect
 	github.com/ipld/go-codec-dagpb v1.4.0 // indirect
-	github.com/ipld/go-ipld-prime v0.17.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect
@@ -167,7 +167,6 @@ require (
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.1.0 // indirect
-	github.com/multiformats/go-multicodec v0.5.0 // indirect
 	github.com/multiformats/go-multihash v0.2.0 // indirect
 	github.com/multiformats/go-multistream v0.3.3 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
@@ -207,7 +206,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.7.0 // indirect
 	go.opentelemetry.io/otel/exporters/zipkin v1.7.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.7.0 // indirect
-	go.opentelemetry.io/otel/trace v1.7.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.16.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/dig v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -647,6 +647,8 @@ github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZ
 github.com/ipfs/interface-go-ipfs-core v0.4.0/go.mod h1:UJBcU6iNennuI05amq3FQ7g0JHUkibHFAfhfUIy927o=
 github.com/ipfs/interface-go-ipfs-core v0.7.0 h1:7tb+2upz8oCcjIyjo1atdMk+P+u7wPmI+GksBlLE8js=
 github.com/ipfs/interface-go-ipfs-core v0.7.0/go.mod h1:lF27E/nnSPbylPqKVXGZghal2hzifs3MmjyiEjnc9FY=
+github.com/ipfs/kubo v0.14.0 h1:qOmR3vd/n+ConnRiXrrLNlj4uek6S9BalMsmhG+a+u8=
+github.com/ipfs/kubo v0.14.0/go.mod h1:i++XWlyJH/PpZNHI//LyoloBFUykQvcbqhmFcW6PQzY=
 github.com/ipfs/tar-utils v0.0.2/go.mod h1:4qlnRWgTVljIMhSG2SqRYn66NT+3wrv/kZt9V+eqxDM=
 github.com/ipld/edelweiss v0.1.4 h1:g4+C2Ph+8SV2MCJBG3oRtetvxJYAS2WzlNGgsOY95iM=
 github.com/ipld/edelweiss v0.1.4/go.mod h1:JX1MR06BPcTOF+5xCYDLnylYkXS15iUN0/RXVSiUIQs=


### PR DESCRIPTION

Implement a basic event schema using IPLD bindnode. Add an example that
shows how to chain the events together and store them in a link system.

Remove `replace` directive in go module pointing to local path.

Run `go mod tidy` to clean up the go module.

Fixes #65