### PR TITLE
Add CI job to build and test go files

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,21 @@
+name: Go Test
+on: [ push, pull_request ]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.19.x"
+      - name: Go information
+        run: |
+          go version
+          go env
+      - name: Run tests
+        run: go test -v -shuffle=on ./...
+      - name: Run tests with race detector
+        run: go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # box
 
+[![Go Test](https://github.com/functionland/go-fula/actions/workflows/go-test.yml/badge.svg)](https://github.com/functionland/go-fula/actions/workflows/go-test.yml)
+
 Client-server stack for Web3
 
 [Intro blog](https://dev.to/fx/google-photos-open-source-alternative-with-react-native-80c#ending-big-techs-reign-by-building-opensource-p2p-apps)


### PR DESCRIPTION
To improve confidence in PRs add a CI job to build and test go files.