### PR TITLE
Generate seeded Ed25519 libp2p identity

### DIFF
--- a/mobile/client.go
+++ b/mobile/client.go
@@ -55,12 +55,18 @@ type Client struct {
 	gx graphsync.GraphExchange
 }
 
+// NewClient instantiates a new Fula mobile Client.
 func NewClient(cfg *Config) (*Client, error) {
 	var mc Client
 	if err := cfg.init(&mc); err != nil {
 		return nil, err
 	}
 	return &mc, nil
+}
+
+// ID returns the libp2p host peer ID of this client.
+func (c Client) ID() peer.ID {
+	return c.h.ID()
 }
 
 // Get gets the value corresponding to the given key from the local ipld.LinkSystem


### PR DESCRIPTION
Add the ability to configure a seed using which the libp2p identity is generated. Fix the identity type to Ed25519 and expose a function to return the peer ID of the host.