### PR TITLE
Implement noop DAG exchange for testing purposes

### DIFF
--- a/exchange/interface.go
+++ b/exchange/interface.go
@@ -1,0 +1,15 @@
+package exchange
+
+import (
+	"context"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type Exchange interface {
+	Start(context.Context) error
+	Push(context.Context, peer.ID, ipld.Link) error
+	Pull(context.Context, peer.ID, ipld.Link) error
+	Shutdown(context.Context) error
+}

--- a/exchange/noop_exchange.go
+++ b/exchange/noop_exchange.go
@@ -1,0 +1,32 @@
+package exchange
+
+import (
+	"context"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+var _ Exchange = (*NoopExchange)(nil)
+
+type NoopExchange struct{}
+
+func (n NoopExchange) Start(context.Context) error {
+	log.Debug("Started noop exchange.")
+	return nil
+}
+
+func (n NoopExchange) Push(ctx context.Context, to peer.ID, l ipld.Link) error {
+	log.Debugw("Pushed noop exchange.", "to", to, "link", l)
+	return nil
+}
+
+func (n NoopExchange) Pull(ctx context.Context, from peer.ID, l ipld.Link) error {
+	log.Debugw("Pulled noop exchange.", "from", from, "link", l)
+	return nil
+}
+
+func (n NoopExchange) Shutdown(ctx context.Context) error {
+	log.Debug("Shut down noop exchange.")
+	return nil
+}

--- a/mobile/client.go
+++ b/mobile/client.go
@@ -44,7 +44,7 @@ type Client struct {
 	h       host.Host
 	ds      datastore.Batching
 	ls      ipld.LinkSystem
-	ex      *exchange.Exchange
+	ex      exchange.Exchange
 	bloxPid peer.ID
 }
 
@@ -168,6 +168,11 @@ func (c *Client) Put(value []byte, codec int64) ([]byte, error) {
 // Shutdown closes all resources used by Client.
 // After calling this function Client must be discarded.
 func (c *Client) Shutdown() error {
-	c.ex.Shutdown()
-	return c.h.Close()
+	ctx := context.TODO()
+	xErr := c.ex.Shutdown(ctx)
+	hErr := c.h.Close()
+	if hErr != nil {
+		return hErr
+	}
+	return xErr
 }


### PR DESCRIPTION
Introduce `noop` exchange, where the operations are only logged and no remote connection is made. This is to enable testing without having to have an accessible Blox API running.

A new config is also introduced in `fulamobile` package called `Exchange`, where if the value is set to `noop` the remote exchange is skipped and `BloxAddr` config may be unspecified.