### PR TITLE
Register DagJSON and Raw codecs

### DIFF
--- a/mobile/client.go
+++ b/mobile/client.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-ipld-prime"
 	_ "github.com/ipld/go-ipld-prime/codec/dagcbor"
+	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
+	_ "github.com/ipld/go-ipld-prime/codec/raw"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	ipldmc "github.com/ipld/go-ipld-prime/multicodec"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"


### PR DESCRIPTION
Register DagJSON and Raw codecs in the list of default codecs supported fulamobile.