### PR TITLE
Close datastore on client shutdown and sync on put

### DIFF
--- a/mobile/client.go
+++ b/mobile/client.go
@@ -172,8 +172,13 @@ func (c *Client) Shutdown() error {
 	ctx := context.TODO()
 	xErr := c.ex.Shutdown(ctx)
 	hErr := c.h.Close()
-	if hErr != nil {
+	dsErr := c.ds.Close()
+	switch {
+	case hErr != nil:
 		return hErr
+	case dsErr != nil:
+		return dsErr
+	default:
+		return xErr
 	}
-	return xErr
 }


### PR DESCRIPTION
Investigate data loss on mobile app closure by: 1) sync on put which should guarantee the data is persisted regardless of options, and 2) closure of datastore on graceful client shutdown.

Note that we are using default settings for badger datastore which has truncation and sync write enabled.