### PR TITLE
Do not attempt connection on noop exchange

### DIFF
--- a/mobile/client.go
+++ b/mobile/client.go
@@ -52,6 +52,9 @@ func NewClient(cfg *Config) (*Client, error) {
 // ConnectToBlox attempts to connect to blox via the configured address. This function can be used
 // to check if blox is currently accessible.
 func (c *Client) ConnectToBlox() error {
+	if _, ok := c.ex.(exchange.NoopExchange); ok {
+		return nil
+	}
 	return c.h.Connect(context.TODO(), c.h.Peerstore().PeerInfo(c.bloxPid))
 }
 


### PR DESCRIPTION
When exchange is set to noop do nothing when `ConnectToBlox` is called and return no error.