### PR TITLE
Add the ability to configure exchange authorization

### DIFF
--- a/blox/blox.go
+++ b/blox/blox.go
@@ -42,7 +42,10 @@ func New(o ...Option) (*Blox, error) {
 	}
 	p.ls.StorageReadOpener = p.blockReadOpener
 	p.ls.StorageWriteOpener = p.blockWriteOpener
-	p.ex = exchange.NewFxExchange(p.h, p.ls)
+	p.ex, err = exchange.NewFxExchange(p.h, p.ls, exchange.WithAuthorizer(p.authorizer))
+	if err != nil {
+		return nil, err
+	}
 	return &p, nil
 }
 
@@ -70,6 +73,10 @@ func (p *Blox) Start(ctx context.Context) error {
 	go p.announceIExistPeriodically()
 	go p.handleAnnouncements()
 	return nil
+}
+
+func (p *Blox) SetAuth(ctx context.Context, on peer.ID, subject peer.ID, allow bool) error {
+	return p.ex.SetAuth(ctx, on, subject, allow)
 }
 
 func (p *Blox) handleAnnouncements() {

--- a/blox/example_test.go
+++ b/blox/example_test.go
@@ -219,6 +219,14 @@ func ExamplePool_ExchangeDagBetweenPoolNodes() {
 		panic(err)
 	}
 
+	// Authorize exchange between the two nodes
+	if err := n1.SetAuth(ctx, h1.ID(), h2.ID(), true); err != nil {
+		panic(err)
+	}
+	if err := n2.SetAuth(ctx, h2.ID(), h1.ID(), true); err != nil {
+		panic(err)
+	}
+
 	// Generate a sample DAG and store it on node 1 (n1) in the pool, which we will pull from n1
 	n1leaf := fluent.MustBuildMap(basicnode.Prototype.Map, 1, func(na fluent.MapAssembler) {
 		na.AssembleEntry("this").AssignBool(true)

--- a/blox/options.go
+++ b/blox/options.go
@@ -14,6 +14,7 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 type (
@@ -25,6 +26,7 @@ type (
 		announceInterval time.Duration
 		ds               datastore.Batching
 		ls               *ipld.LinkSystem
+		authorizer       peer.ID
 	}
 )
 
@@ -71,6 +73,9 @@ func newOptions(o ...Option) (*options, error) {
 			}
 			return bytes.NewBuffer(val), nil
 		}
+	}
+	if opts.authorizer == "" {
+		opts.authorizer = opts.h.ID()
 	}
 	return &opts, nil
 }
@@ -123,6 +128,15 @@ func WithDatastore(ds datastore.Batching) Option {
 func WithLinkSystem(ls *ipld.LinkSystem) Option {
 	return func(o *options) error {
 		o.ls = ls
+		return nil
+	}
+}
+
+// WithAuthorizer sets the peer ID that has permission to configure DAG exchange authorization.
+// Defaults to the blox libp2p host ID if unset.
+func WithAuthorizer(pid peer.ID) Option {
+	return func(o *options) error {
+		o.authorizer = pid
 		return nil
 	}
 }

--- a/exchange/interface.go
+++ b/exchange/interface.go
@@ -11,5 +11,6 @@ type Exchange interface {
 	Start(context.Context) error
 	Push(context.Context, peer.ID, ipld.Link) error
 	Pull(context.Context, peer.ID, ipld.Link) error
+	SetAuth(context.Context, peer.ID, peer.ID, bool) error
 	Shutdown(context.Context) error
 }

--- a/exchange/noop_exchange.go
+++ b/exchange/noop_exchange.go
@@ -16,17 +16,22 @@ func (n NoopExchange) Start(context.Context) error {
 	return nil
 }
 
-func (n NoopExchange) Push(ctx context.Context, to peer.ID, l ipld.Link) error {
+func (n NoopExchange) Push(_ context.Context, to peer.ID, l ipld.Link) error {
 	log.Debugw("Pushed noop exchange.", "to", to, "link", l)
 	return nil
 }
 
-func (n NoopExchange) Pull(ctx context.Context, from peer.ID, l ipld.Link) error {
+func (n NoopExchange) Pull(_ context.Context, from peer.ID, l ipld.Link) error {
 	log.Debugw("Pulled noop exchange.", "from", from, "link", l)
 	return nil
 }
 
-func (n NoopExchange) Shutdown(ctx context.Context) error {
+func (n NoopExchange) SetAuth(_ context.Context, on peer.ID, subject peer.ID, allow bool) error {
+	log.Debugw("Set auth noop exchange.", "on", on, "subject", subject, "allow", allow)
+	return nil
+}
+
+func (n NoopExchange) Shutdown(context.Context) error {
 	log.Debug("Shut down noop exchange.")
 	return nil
 }

--- a/exchange/options.go
+++ b/exchange/options.go
@@ -1,0 +1,29 @@
+package exchange
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type (
+	Option  func(*options) error
+	options struct {
+		authorizer peer.ID
+	}
+)
+
+func newOptions(o ...Option) (*options, error) {
+	var opts options
+	for _, apply := range o {
+		if err := apply(&opts); err != nil {
+			return nil, err
+		}
+	}
+	return &opts, nil
+}
+
+func WithAuthorizer(a peer.ID) Option {
+	return func(o *options) error {
+		o.authorizer = a
+		return nil
+	}
+}

--- a/mobile/client.go
+++ b/mobile/client.go
@@ -214,6 +214,19 @@ func (c *Client) Flush() error {
 	return c.ds.Sync(context.TODO(), rootDatastoreKey)
 }
 
+// SetAuth sets authorization on the given peer ID for the given subject.
+func (c *Client) SetAuth(on string, subject string, allow bool) error {
+	onp, err := peer.Decode(on)
+	if err != nil {
+		return err
+	}
+	subp, err := peer.Decode(subject)
+	if err != nil {
+		return err
+	}
+	return c.ex.SetAuth(context.TODO(), onp, subp, allow)
+}
+
 // Shutdown closes all resources used by Client.
 // After calling this function Client must be discarded.
 func (c *Client) Shutdown() error {


### PR DESCRIPTION
Add functionality that allows the user to specify a peer ID as `authorizer`. The `authorizer` is then allowed to configure authorization for other peers.

Integrate authorization in both blox, and fula mobile client.