### PR TITLE
Use an OS-agnostic character to print QR code

### DIFF
--- a/cmd/blox/main.go
+++ b/cmd/blox/main.go
@@ -238,7 +238,14 @@ func printMultiaddrAsQR(h host.Host) {
 	}
 	as := fmt.Sprintf("%s/p2p/%s", addr.String(), h.ID().String())
 	fmt.Printf(">>> blox multiaddr: %s\n", as)
-	qrterminal.Generate(as, qrterminal.L, os.Stdout)
+	qrterminal.GenerateWithConfig(as, qrterminal.Config{
+		Level:      qrterminal.L,
+		Writer:     os.Stdout,
+		HalfBlocks: false,
+		BlackChar:  "%%",
+		WhiteChar:  "  ",
+		QuietZone:  qrterminal.QUIET_ZONE,
+	})
 }
 
 func main() {


### PR DESCRIPTION
To make sure QR code generation works no matter what, use a simple character as black character. This looks less nice but works in basic tests and should be safe no matter what the terminal config.