### PR TITLE
Add force private and transient connectivity options

### DIFF
--- a/blox/blox.go
+++ b/blox/blox.go
@@ -42,7 +42,9 @@ func New(o ...Option) (*Blox, error) {
 	}
 	p.ls.StorageReadOpener = p.blockReadOpener
 	p.ls.StorageWriteOpener = p.blockWriteOpener
-	p.ex, err = exchange.NewFxExchange(p.h, p.ls, exchange.WithAuthorizer(p.authorizer))
+	p.ex, err = exchange.NewFxExchange(p.h, p.ls,
+		exchange.WithAuthorizer(p.authorizer),
+		exchange.WithAllowTransientConnection(p.allowTransientConnection))
 	if err != nil {
 		return nil, err
 	}

--- a/blox/options.go
+++ b/blox/options.go
@@ -20,13 +20,14 @@ import (
 type (
 	Option  func(*options) error
 	options struct {
-		h                host.Host
-		name             string
-		topicName        string
-		announceInterval time.Duration
-		ds               datastore.Batching
-		ls               *ipld.LinkSystem
-		authorizer       peer.ID
+		h                        host.Host
+		name                     string
+		topicName                string
+		announceInterval         time.Duration
+		ds                       datastore.Batching
+		ls                       *ipld.LinkSystem
+		authorizer               peer.ID
+		allowTransientConnection bool
 	}
 )
 
@@ -137,6 +138,13 @@ func WithLinkSystem(ls *ipld.LinkSystem) Option {
 func WithAuthorizer(pid peer.ID) Option {
 	return func(o *options) error {
 		o.authorizer = pid
+		return nil
+	}
+}
+
+func WithAllowTransientConnection(t bool) Option {
+	return func(o *options) error {
+		o.allowTransientConnection = t
 		return nil
 	}
 }

--- a/exchange/options.go
+++ b/exchange/options.go
@@ -7,7 +7,8 @@ import (
 type (
 	Option  func(*options) error
 	options struct {
-		authorizer peer.ID
+		authorizer               peer.ID
+		allowTransientConnection bool
 	}
 )
 
@@ -24,6 +25,13 @@ func newOptions(o ...Option) (*options, error) {
 func WithAuthorizer(a peer.ID) Option {
 	return func(o *options) error {
 		o.authorizer = a
+		return nil
+	}
+}
+
+func WithAllowTransientConnection(t bool) Option {
+	return func(o *options) error {
+		o.allowTransientConnection = t
 		return nil
 	}
 }


### PR DESCRIPTION
Add options to control forced private reachability and allow transient connectivity. The options would allow connection via relay when a node
 is behind NAT.