### PR TITLE
accept format parameter for listFAiledPushes

### DIFF
--- a/mobile/client.go
+++ b/mobile/client.go
@@ -186,8 +186,8 @@ func (c *Client) Put(value []byte, codec int64) ([]byte, error) {
 	return link.(cidlink.Link).Cid.Bytes(), nil
 }
 
-func (c *Client) ListFailedPushes() (*LinkIterator, error) {
-	links, err := c.listFailedPushes(context.TODO())
+func (c *Client) ListFailedPushes(format string) (*LinkIterator, error) {
+	links, err := c.listFailedPushes(context.TODO(), format)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (c *Client) ListFailedPushes() (*LinkIterator, error) {
 // See ListFailedPushes.
 func (c *Client) RetryFailedPushes() error {
 	ctx := context.TODO()
-	links, err := c.listFailedPushes(ctx)
+	links, err := c.listFailedPushes(ctx, "byte")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
the format parameter defines if failed pushes should be returns as byte array or as a cid string. So if format is "byte": output will be like ["[1, 113, 18, 32, 119, 27, 149, 78, 121, 176, 250, 106, 248, 214, 52, 237, 220, 18, 171, 244, 63, 48, 57, 210, 200, 180, 185, 198, 25, 15, 253, 235, 178, 106, 210, 64]"]

if format is "string": ["bafyreidxdoku46nq7jvprvru5xobfk7uh4ydtuwiws44mgip7xv3e2wsia"]