### PR TITLE
Update ensure-podspec-version.yml

### DIFF
--- a/.github/workflows/ensure-podspec-version.yml
+++ b/.github/workflows/ensure-podspec-version.yml
@@ -15,8 +15,8 @@ jobs:
     - name: Update version
       run: |
         VERSION=$(echo ${{ github.event.release.tag_name }} | cut -c 2-) # remove the v from the tag name
-        sed -i 's/\(s.version\s*=\s*\).*$/\1\''"$VERSION"'\'/' Fula.podspec
-        sed -i 's/#{s.version}/'"$VERSION"'/' Fula.podspec
+        sed -i 's/\(s.version\s*=\s*\).*$/\1'"\"$VERSION\""'/g' Fula.podspec
+        sed -i 's/#{s.version}/'"$VERSION"'/g' Fula.podspec
 
     - name: Set up Git
       run: |


### PR DESCRIPTION
Correcting error:
Run VERSION=$(echo v1.14.0 | cut -c 2-) # remove the v from the tag name
  VERSION=$(echo v1.14.0 | cut -c 2-) # remove the v from the tag name
  sed -i 's/\(s.version\s*=\s*\).*$/\1\''"$VERSION"'\'/' Fula.podspec
  sed -i 's/#{s.version}/'"$VERSION"'/' Fula.podspec
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/2da18604-9914-4133-876d-268891af60c5.sh: line 3: unexpected EOF while looking for matching `'' Error: Process completed with exit code 2.