### PR TITLE
Add option to disable the libp2p resource manager

### DIFF
--- a/cmd/blox/main.go
+++ b/cmd/blox/main.go
@@ -35,6 +35,7 @@ import (
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -87,6 +88,7 @@ var (
 			StaticRelays              []string      `yaml:"staticRelays"`
 			ForceReachabilityPrivate  bool          `yaml:"forceReachabilityPrivate"`
 			AllowTransientConnection  bool          `yaml:"allowTransientConnection"`
+			DisableResourceManger     bool          `yaml:"disableResourceManger"`
 			MaxCIDPushRate            int           `yaml:"maxCIDPushRate"`
 			IpniPublishDisabled       bool          `yaml:"ipniPublishDisabled"`
 			IpniPublishInterval       time.Duration `yaml:"ipniPublishInterval"`
@@ -319,6 +321,13 @@ func init() {
 				Usage:       "Weather to allow transient connection to other participants.",
 				Destination: &app.config.AllowTransientConnection,
 				Value:       true,
+			}),
+			altsrc.NewBoolFlag(&cli.BoolFlag{
+				Name:        "disableResourceManger",
+				Aliases:     []string{"drm"},
+				Usage:       "Weather to disable the libp2p resource manager.",
+				Destination: &app.config.DisableResourceManger,
+				Value:       false,
 			}),
 			altsrc.NewIntFlag(&cli.IntFlag{
 				Name:        "maxCIDPushRate",
@@ -658,6 +667,9 @@ func action(ctx *cli.Context) error {
 
 	if app.config.ForceReachabilityPrivate {
 		hopts = append(hopts, libp2p.ForceReachabilityPrivate())
+	}
+	if app.config.DisableResourceManger {
+		hopts = append(hopts, libp2p.ResourceManager(&network.NullResourceManager{}))
 	}
 
 	sr := make([]peer.AddrInfo, 0, len(app.config.StaticRelays))

--- a/mobile/config.go
+++ b/mobile/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -48,6 +49,9 @@ type Config struct {
 	// ForceReachabilityPrivate configures weather the libp2p should always think that it is behind
 	// NAT.
 	ForceReachabilityPrivate bool
+
+	// DisableResourceManger sets whether to disable the libp2p resource manager.
+	DisableResourceManger bool
 
 	// SyncWrites assures that writes to the local datastore are flushed to the backing store as
 	// soon as they are written. By default, writes are not synchronized to disk until either the
@@ -82,6 +86,9 @@ func (cfg *Config) init(mc *Client) error {
 		libp2p.NATPortMap(),
 		libp2p.EnableRelay(),
 		libp2p.EnableHolePunching(),
+	}
+	if cfg.DisableResourceManger {
+		hopts = append(hopts, libp2p.ResourceManager(&network.NullResourceManager{}))
 	}
 	mc.relays = cfg.StaticRelays
 	if len(cfg.StaticRelays) != 0 {

--- a/wap/pkg/config/config.go
+++ b/wap/pkg/config/config.go
@@ -63,7 +63,7 @@ func init() {
 	COUNTRY = getEnv("COUNTRY", "GB")
 	PROJECT_ROOT = getEnv("PROJECT_ROOT", "../..")
 	FULA_CONFIG_PATH = getEnv("FULA_CONFIG_PATH", "/internal/config.yaml")
-	BLOX_COMMAND = fmt.Sprintf(getEnv("BLOX_COMMAND", "/app --authorizer %%s --identity %%s --initOnly --config %s --storeDir /uniondrive"), FULA_CONFIG_PATH)
+	BLOX_COMMAND = fmt.Sprintf(getEnv("BLOX_COMMAND", "/app --authorizer %%s --identity %%s --initOnly --config %s --storeDir /uniondrive --disableResourceManger true --maxCIDPushRate 100 --logLevel info"), FULA_CONFIG_PATH)
 	OTA_VERSION = getEnv("OTA_VERSION", "6")
 	HOTSPOT_SSID = getEnv("HOTSPOT_SSID", "FxBlox")
 	RESTART_NEEDED_AFTER = getEnv("RESTART_NEEDED_AFTER", "6")


### PR DESCRIPTION
Add option to disable the libp2p resource manger both for the blox and mobile client implementation.